### PR TITLE
docker url on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ graph LR
 
 > **Note:** The system consists of two main components: parsing and LLM. Currently, parsing utilizes Upstage and OpenAI APIs (which showed the best performance in our testing) with a local parser coming soon, while the LLM component can run fully locally using Ollama.
 
-> **Note:** If you're using Ollama with Docker, make sure to set the Ollama API endpoint to: `http://docker.for.mac.localhost:11434/`
+> **Note:** If you're using Ollama with Docker, make sure to set the Ollama API endpoint to: `http://docker.for.mac.localhost:11434/` on a Mac or `http://host.docker.internal:11434/` on Windows.
 
 </details>
 


### PR DESCRIPTION
## What's changed?
adding the Docker URL on Windows (might be universal?). 
The instructions state that the app is run using Docker, which uses a Postgres Docker container. However, it is not possible to connect to it using the default settings.