### PR TITLE
remove compose version setting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   database:
     image: postgres


### PR DESCRIPTION
Docker recommends not using the version setting. It is showing as a warning.

## What's changed?
When building the docker dontainer, the warning pops up stating that the version setting is deprecated.
This is to minimize the number of unnecessary errors and warnings and to be able to focus only on the important/unexpected ones.