### PR TITLE
Add SQLite support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ POSTGRES_USER=postgres
 POSTGRES_DB=open-health
 UPSTAGE_API_KEY=up_
 OPENAI_API_KEY=sk-
+# Example SQLite database URL
+DATABASE_URL=sqlite:./dev.db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,12 +13,20 @@ services:
     ports:
       - "5432:5432"
 
+  sqlite:
+    image: nouchka/sqlite3
+    restart: always
+    volumes:
+      - sqlite_data:/var/lib/sqlite3/data
+    environment:
+      SQLITE_DB: ${SQLITE_DB}
+
   app:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/${POSTGRES_DB}
+        - DATABASE_URL=${DATABASE_URL}
     depends_on:
       - database
     volumes:
@@ -27,8 +35,9 @@ services:
       - "3000:3000"
     restart: always
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/${POSTGRES_DB}
+      DATABASE_URL: ${DATABASE_URL}
 
 volumes:
   postgres_data:
+  sqlite_data:
   app_data:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = env("DATABASE_PROVIDER")
   url      = env("DATABASE_URL")
 }
 

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,18 +1,30 @@
-import {PrismaClient} from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 
 export function createPrismaClient() {
-    return new PrismaClient({
-        log: ['warn', 'error']
-    });
+  const databaseProvider = process.env.DATABASE_PROVIDER || "postgresql";
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL environment variable is not set");
+  }
+
+  return new PrismaClient({
+    log: ["warn", "error"],
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
 }
 
 declare const globalThis: {
-    prismaGlobal: ReturnType<typeof createPrismaClient>;
+  prismaGlobal: ReturnType<typeof createPrismaClient>;
 } & typeof global;
 
-const prisma = globalThis.prismaGlobal ?? createPrismaClient()
+const prisma = globalThis.prismaGlobal ?? createPrismaClient();
 
-export default prisma
-export {Prisma} from "@prisma/client";
+export default prisma;
+export { Prisma } from "@prisma/client";
 
-if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma
+if (process.env.NODE_ENV !== "production") globalThis.prismaGlobal = prisma;


### PR DESCRIPTION
Related to #49

Add support for SQLite as an alternative to PostgreSQL.

* **docker-compose.yaml**
  - Add a new service for SQLite.
  - Update the `app` service to use SQLite if specified.
  - Add a volume for SQLite data.

* **prisma/schema.prisma**
  - Update the `datasource db` block to support both PostgreSQL and SQLite.

* **src/lib/prisma.ts**
  - Update the `createPrismaClient` function to support both PostgreSQL and SQLite.

* **.env.example**
  - Add an example `DATABASE_URL` for SQLite.

