### PR TITLE
Integrate Google Health data

### DIFF
--- a/src/app/api/google-health/route.ts
+++ b/src/app/api/google-health/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getGoogleHealthData, saveHealthData } from "@/lib/google-health/data";
+import { authenticateGoogleHealth } from "@/lib/google-health/auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const authToken = await authenticateGoogleHealth(req);
+    const healthData = await getGoogleHealthData(authToken);
+    return NextResponse.json({ healthData });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    const savedData = await saveHealthData(data);
+    return NextResponse.json({ savedData });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/lib/google-health/auth.ts
+++ b/src/lib/google-health/auth.ts
@@ -1,0 +1,43 @@
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+const oauth2Client = new OAuth2Client(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+
+export function getAuthUrl() {
+  const scopes = [
+    'https://www.googleapis.com/auth/fitness.activity.read',
+    'https://www.googleapis.com/auth/fitness.body.read',
+    'https://www.googleapis.com/auth/fitness.location.read',
+  ];
+
+  return oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: scopes,
+  });
+}
+
+export async function getToken(code: string) {
+  const { tokens } = await oauth2Client.getToken(code);
+  oauth2Client.setCredentials(tokens);
+  return tokens;
+}
+
+export async function refreshToken(refreshToken: string) {
+  oauth2Client.setCredentials({ refresh_token: refreshToken });
+  const { credentials } = await oauth2Client.refreshAccessToken();
+  return credentials;
+}
+
+export async function authenticateGoogleHealth(req: any) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    throw new Error('No token provided');
+  }
+
+  oauth2Client.setCredentials({ access_token: token });
+  return token;
+}

--- a/src/lib/google-health/data.ts
+++ b/src/lib/google-health/data.ts
@@ -1,0 +1,59 @@
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+
+const oauth2Client = new OAuth2Client(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+
+async function fetchGoogleHealthData(authToken: string) {
+  oauth2Client.setCredentials({ access_token: authToken });
+
+  const fitness = google.fitness({ version: 'v1', auth: oauth2Client });
+
+  const dataSources = await fitness.users.dataSources.list({
+    userId: 'me',
+  });
+
+  const healthData = [];
+
+  for (const dataSource of dataSources.data.dataSource || []) {
+    const dataSet = await fitness.users.dataSources.datasets.get({
+      userId: 'me',
+      dataSourceId: dataSource.dataStreamId,
+      datasetId: '0-9999999999999',
+    });
+
+    healthData.push({
+      dataSource: dataSource.dataStreamName,
+      data: dataSet.data.point,
+    });
+  }
+
+  return healthData;
+}
+
+function parseGoogleHealthData(rawData: any) {
+  return rawData.map((data: any) => {
+    return {
+      source: data.dataSource,
+      values: data.data.map((point: any) => ({
+        startTime: point.startTimeNanos,
+        endTime: point.endTimeNanos,
+        value: point.value,
+      })),
+    };
+  });
+}
+
+export async function getGoogleHealthData(authToken: string) {
+  const rawData = await fetchGoogleHealthData(authToken);
+  return parseGoogleHealthData(rawData);
+}
+
+export async function saveHealthData(data: any) {
+  // Implement the logic to save health data to the database
+  // This is a placeholder function and should be replaced with actual implementation
+  return data;
+}


### PR DESCRIPTION
Related to #29

Add integration with Google Health to allow users to import and manage their health data.

* **API Endpoint**: Add `src/app/api/google-health/route.ts` to handle Google Health data import with GET and POST methods.
* **OAuth2 Authentication**: Add `src/lib/google-health/auth.ts` to implement OAuth2 authentication flow for Google Health API, including token exchange and refresh functions.
* **Data Fetching and Parsing**: Add `src/lib/google-health/data.ts` to fetch and parse health data from Google Health API, and implement a placeholder function to save imported health data to the database.
* **UI Update**: Modify `src/components/source/source-add-screen.tsx` to include an option for importing data from Google Health, and implement functions to handle the import process and update the state.

