### PR TITLE
fix: add missing ghostscript package

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine
 LABEL authors="OpenHealth"
 
-RUN apk add -U graphicsmagick
+RUN apk add -U graphicsmagick ghostscript
 
 WORKDIR /app
 


### PR DESCRIPTION
## What's changed?
Added missing ghostscript package to container build.  This fixes an issue where uploaded PDFs failed to parse.