### PR TITLE
Fix: Add authentication and ownership checks to health-data [id] API routes

### DIFF
--- a/src/app/api/health-data/[id]/route.ts
+++ b/src/app/api/health-data/[id]/route.ts
@@ -1,6 +1,7 @@
 import {NextRequest, NextResponse} from "next/server";
 import prisma, {Prisma} from "@/lib/prisma";
 import {HealthData} from "@/app/api/health-data/route";
+import {auth} from "@/auth";
 
 export interface HealthDataPatchRequest {
     data?: Prisma.InputJsonValue
@@ -14,8 +15,15 @@ export async function GET(
     req: NextRequest,
     {params}: { params: Promise<{ id: string }> }
 ) {
+    const session = await auth()
+    if (!session || !session.user) return NextResponse.json({error: 'Unauthorized'}, {status: 401})
+
     const {id} = await params
-    const healthData = await prisma.healthData.findUniqueOrThrow({where: {id}})
+    const healthData = await prisma.healthData.findFirst({
+        where: {id, authorId: session.user.id}
+    })
+    if (!healthData) return NextResponse.json({error: 'Not found'}, {status: 404})
+
     return NextResponse.json({healthData})
 }
 
@@ -23,8 +31,17 @@ export async function PATCH(
     req: NextRequest,
     {params}: { params: Promise<{ id: string }> }
 ) {
+    const session = await auth()
+    if (!session || !session.user) return NextResponse.json({error: 'Unauthorized'}, {status: 401})
+
     const {id} = await params
     const body: HealthDataPatchRequest = await req.json()
+
+    // Verify ownership before updating
+    const existing = await prisma.healthData.findFirst({
+        where: {id, authorId: session.user.id}
+    })
+    if (!existing) return NextResponse.json({error: 'Not found'}, {status: 404})
 
     const healthData = await prisma.healthData.update({
         where: {id},
@@ -37,7 +54,17 @@ export async function DELETE(
     req: NextRequest,
     {params}: { params: Promise<{ id: string }> }
 ) {
+    const session = await auth()
+    if (!session || !session.user) return NextResponse.json({error: 'Unauthorized'}, {status: 401})
+
     const {id} = await params
+
+    // Verify ownership before deleting
+    const existing = await prisma.healthData.findFirst({
+        where: {id, authorId: session.user.id}
+    })
+    if (!existing) return NextResponse.json({error: 'Not found'}, {status: 404})
+
     await prisma.healthData.delete({where: {id}})
     return NextResponse.json({})
 }

--- a/src/app/api/health-data/[id]/route.ts
+++ b/src/app/api/health-data/[id]/route.ts
@@ -60,12 +60,9 @@ export async function DELETE(
 
     const {id} = await params
 
-    // Verify ownership before deleting
-    const existing = await prisma.healthData.findFirst({
+    const {count} = await prisma.healthData.deleteMany({
         where: {id, authorId: session.user.id}
     })
-    if (!existing) return NextResponse.json({error: 'Not found'}, {status: 404})
-
-    await prisma.healthData.delete({where: {id}})
+    if (count === 0) return NextResponse.json({error: 'Not found'}, {status: 404})
     return NextResponse.json({})
 }

--- a/src/app/api/health-data/[id]/route.ts
+++ b/src/app/api/health-data/[id]/route.ts
@@ -45,7 +45,8 @@ export async function PATCH(
 
     const healthData = await prisma.healthData.update({
         where: {id},
-        data: body
+        data: { data: body.data }
+    })
     })
     return NextResponse.json({healthData})
 }


### PR DESCRIPTION
The GET, PATCH, and DELETE endpoints for individual health data records had no authentication or authorization checks. Any unauthenticated request with a valid record ID could read, modify, or delete any user's health data — a critical security vulnerability for a health application.

This change:
- Adds session authentication check (returns 401 if not logged in)
- Adds ownership verification using authorId (returns 404 if the record doesn't belong to the current user, preventing IDOR attacks)
- Uses findFirst with authorId filter instead of findUniqueOrThrow to avoid leaking existence of other users' records via error messages

The parent route (/api/health-data) already had these checks — this brings the [id] sub-route to the same security standard.

---
name: Add authentication and ownership checks to health-data [id] routes
about: Adds missing authentication and authorization checks to the `/api/health-data/[id]` 
GET, PATCH, and DELETE endpoints.
---

<!-- 👋 Thanks for contributing! A few quick things:
- 📚 See our contributing guide: https://github.com/OpenHealthForAll/open-health/blob/main/CONTRIBUTING.md
- 🌱 New contributor? Try our good first issues: https://github.com/OpenHealthForAll/open-health/labels/good%20first%20issue -->

## What's changed?
The individual health data record endpoints had **no authentication or authorization 
checks**. Any unauthenticated request with a valid record ID could:
- **Read** any user's health data (GET)
- **Modify** any user's health data (PATCH)  
- **Delete** any user's health data (DELETE)

This is a critical security vulnerability (IDOR - Insecure Direct Object Reference) 
for a health application handling sensitive patient data.

The parent route (`/api/health-data`) already has proper `auth()` checks — this 
sub-route was missing them.

## Fix

- Added `auth()` session check → returns 401 if not logged in
- Added ownership verification via `authorId` filter → returns 404 if the record 
  doesn't belong to the current user
- Uses `findFirst` with `authorId` instead of `findUniqueOrThrow` to avoid leaking 
  existence of other users' records

## Type of change

- [x] Security fix

## ✨ Screenshots (optional)
<!-- Add screenshots if helpful --> 